### PR TITLE
fix: misc changes

### DIFF
--- a/frontend/src/components/RouteDashboard.js
+++ b/frontend/src/components/RouteDashboard.js
@@ -53,7 +53,7 @@ const RouteDashboard = () => {
             name: "average_delay",
             label: "Average Lateness (min)",
             options: {
-                customBodyRender: (value, { rowIndex }) => {
+                customBodyRender: (value) => {
                     const minutes = Math.round(value / 60)
                     return <Typography>{`${minutes}`}</Typography>
                 },
@@ -64,8 +64,7 @@ const RouteDashboard = () => {
             name: "very_late_percentage",
             label: "% Vehicles >5 minutes late",
             options: {
-                customBodyRender: (value, { rowIndex }) => {
-                    const rowObject = routes[rowIndex];
+                customBodyRender: (value) => {
                     const percentage = value; /*Math.floor((value / rowObject["vehicle_count"]) * 100)*/
                     return <Typography>{`${percentage}%`}</Typography>
                 },
@@ -89,7 +88,8 @@ const RouteDashboard = () => {
         print: false,
         download: false,
         filter: false,
-        responsive: 'standard'
+        responsive: 'standard',
+        viewColumns: false
     };
 
     useEffect(() => {

--- a/frontend/src/components/StopsDashboard.js
+++ b/frontend/src/components/StopsDashboard.js
@@ -51,8 +51,7 @@ const StopsDashboard = () => {
             label: "% Vehicles > 5 Min Late",
             options: {
                 customBodyRender: (value, { rowIndex }) => {
-                    const rowObject = stops[rowIndex];
-                    const percentage = value/*Math.floor((value / rowObject["stop_count"]) * 100)*/;
+                    const percentage = value
                     return <Typography>{`${percentage}%`}</Typography>
                 },
                 searchable: false
@@ -82,6 +81,7 @@ const StopsDashboard = () => {
         download: false,
         filter: false,
         responsive: 'standard',
+        viewColumns: false,
         sortOrder: {
             name: 'stop_name',
             direction: 'asc'

--- a/frontend/src/components/StopsExpandableRow.js
+++ b/frontend/src/components/StopsExpandableRow.js
@@ -1,14 +1,13 @@
 import React, { useState, useEffect, useCallback } from "react";
-import MUIDataTable from "mui-datatables";
 import { TableRow, TableCell, CircularProgress, Box } from "@mui/material";
 
 import service from "../services/services";
-import { convertUnixTimeToPST } from "../utils/time";
 import moment from 'moment-timezone'
 import DelayLineChart from "./charts/DelayLineChart";
 import VeryLateLineChart from "./charts/VeryLateLineChart";
 import VeryEarlyLineChart from './charts/VeryEarlyLineChart';
 import VehicleCountLineChart from "./charts/VehicleCountLineChart";
+import StopVehicleDetailsTable from "./tables/StopVehicleDetailsTable";
 
 const StopsExpandableRow = ({ rowData, stop }) => {
     const [updates, setUpdates] = useState([]);
@@ -78,8 +77,10 @@ const StopsExpandableRow = ({ rowData, stop }) => {
             }}
         >
             <TableCell colSpan={colSpan}>
-                {historicalDataLoading ? <CircularProgress /> : (
-                    <Box
+                {
+                    (updatesLoading || historicalDataLoading) ? <CircularProgress /> : (
+                        <>
+                         <Box
                         sx={{
                             display: 'grid',
                             gap: 2,
@@ -92,47 +93,8 @@ const StopsExpandableRow = ({ rowData, stop }) => {
                         <VeryLateLineChart data={historicalData} />
                         <VeryEarlyLineChart data={historicalData} />
                     </Box>
-                )}
-                {
-                    updatesLoading ? <CircularProgress /> : (
-                        <MUIDataTable
-                            title={`Updates at Stop: ${stop.stop_name}`}
-                            data={updates.map((update) => ({
-                                label: update.vehicle_label,
-                                number: update.route_short_name,
-                                direction: update.direction_name,
-                                lateness: update.delay / 60,
-                                stopTime: convertUnixTimeToPST(moment.utc(update.stop_time).valueOf()),
-                                lastUpdate: convertUnixTimeToPST(moment.utc(update.update_time).valueOf()),
-                            }))}
-                            columns={[
-                                { name: "label", label: "Vehicle Label" },
-                                { name: "number", label: "Number" },
-                                { name: "direction", label: "Direction" },
-                                {
-                                    name: "lateness",
-                                    label: "Delay (min)",
-                                    options: {
-                                        customBodyRender: (value) => Math.round(value)
-                                    }
-                                },
-                                { name: "stopTime", label: "Stop Time" },
-                                { name: "lastUpdate", label: "Last Update" },
-                            ]}
-                            options={{
-                                selectableRows: "none",
-                                pagination: false,
-                                search: false,
-                                print: false,
-                                download: false,
-                                filter: false,
-                                responsive: 'standard',
-                                sortOrder: {
-                                    name: 'stopTime',
-                                    direction: 'asc'
-                                }
-                            }}
-                        />
+                    <StopVehicleDetailsTable stop={stop} updates={updates} />
+                        </>
                     )
                 }
             </TableCell>

--- a/frontend/src/components/charts/DelayLineChart.js
+++ b/frontend/src/components/charts/DelayLineChart.js
@@ -13,7 +13,7 @@ const DelayLineChart = ({ data }) => {
 
     const tooltipLabelFormatter = (label) => convertUnixTimeToPST(label)
 
-    const tooltipFormatter = (value) => [`${Math.round(value)} min`, 'Average delay']
+    const tooltipFormatter = (value) => [`${Math.round(value*10)/10} min`, 'Average delay']
 
 
     const handleTimeRangeChange = (event) => {

--- a/frontend/src/components/charts/VeryEarlyLineChart.js
+++ b/frontend/src/components/charts/VeryEarlyLineChart.js
@@ -13,7 +13,7 @@ const VeryLateLineChart = ({ data }) => {
 
     const tooltipLabelFormatter = (label) => convertUnixTimeToPST(label)
 
-    const tooltipFormatter = (value) => [`${value} %`, 'Percentage']
+    const tooltipFormatter = (value) => [`${Math.round(value * 10) / 10} %`, 'Percentage']
 
 
     const handleTimeRangeChange = (event) => {

--- a/frontend/src/components/charts/VeryLateLineChart.js
+++ b/frontend/src/components/charts/VeryLateLineChart.js
@@ -13,7 +13,7 @@ const VeryLateLineChart = ({ data }) => {
 
     const tooltipLabelFormatter = (label) => convertUnixTimeToPST(label)
 
-    const tooltipFormatter = (value) => [`${value} %`, 'Percentage']
+    const tooltipFormatter = (value) => [`${Math.round(value * 10) / 10} %`, 'Percentage']
 
     const handleTimeRangeChange = (event) => {
         const selectedRange = event.target.value;

--- a/frontend/src/components/tables/RouteVehicleDetailsTable.js
+++ b/frontend/src/components/tables/RouteVehicleDetailsTable.js
@@ -1,0 +1,42 @@
+import MUIDataTable from "mui-datatables";
+import { convertUnixTimeToPST } from "../../utils/time";
+import moment from 'moment-timezone';
+import { ThemeProvider } from "@mui/material";
+import { getMuiTheme } from "./utils";
+
+const RouteVehicleDetailsTable = ({ vehicles }) => {
+
+    return (
+        <ThemeProvider theme={getMuiTheme()}>
+            <MUIDataTable
+                title={"Vehicle Details"}
+                data={vehicles.map((bus) => ({
+                    label: bus.vehicle_label,
+                    lateness: Math.round(bus.delay / 60),
+                    nextStop: bus.stop_name,
+                    lastUpdate: convertUnixTimeToPST(moment.utc(bus.update_time).valueOf()),
+                    expectedArrival: convertUnixTimeToPST(moment.utc(bus.expected_arrival).valueOf()),
+                }))}
+                columns={[
+                    { name: "label", label: "Bus Label" },
+                    { name: "lateness", label: "Lateness (min)" },
+                    { name: "nextStop", label: "Next Stop" },
+                    { name: "expectedArrival", label: "Expected Arrival Time" },
+                    { name: "lastUpdate", label: "Last Update" },
+                ]}
+                options={{
+                    selectableRows: "none",
+                    pagination: false,
+                    search: false,
+                    print: false,
+                    download: false,
+                    filter: false,
+                    responsive: 'standard',
+                    viewColumns: false
+                }}
+            />
+        </ThemeProvider>
+    )
+}
+
+export default RouteVehicleDetailsTable

--- a/frontend/src/components/tables/StopVehicleDetailsTable.js
+++ b/frontend/src/components/tables/StopVehicleDetailsTable.js
@@ -1,0 +1,53 @@
+import MUIDataTable from "mui-datatables";
+import { convertUnixTimeToPST } from "../../utils/time";
+import moment from 'moment-timezone';
+import { ThemeProvider } from "@mui/material";
+import { getMuiTheme } from "./utils";
+
+const StopVehicleDetailsTable = ({ stop, updates }) => {
+    return (
+        <ThemeProvider theme={getMuiTheme()}>
+            <MUIDataTable
+                title={`Updates at Stop: ${stop.stop_name}`}
+                data={updates.map((update) => ({
+                    label: update.vehicle_label,
+                    number: update.route_short_name,
+                    direction: update.direction_name,
+                    lateness: update.delay / 60,
+                    stopTime: convertUnixTimeToPST(moment.utc(update.stop_time).valueOf()),
+                    lastUpdate: convertUnixTimeToPST(moment.utc(update.update_time).valueOf()),
+                }))}
+                columns={[
+                    { name: "label", label: "Vehicle Label" },
+                    { name: "number", label: "Number" },
+                    { name: "direction", label: "Direction" },
+                    {
+                        name: "lateness",
+                        label: "Delay (min)",
+                        options: {
+                            customBodyRender: (value) => Math.round(value)
+                        }
+                    },
+                    { name: "stopTime", label: "Stop Time" },
+                    { name: "lastUpdate", label: "Last Update" },
+                ]}
+                options={{
+                    selectableRows: "none",
+                    pagination: false,
+                    search: false,
+                    print: false,
+                    download: false,
+                    filter: false,
+                    responsive: 'standard',
+                    viewColumns: false,
+                    sortOrder: {
+                        name: 'stopTime',
+                        direction: 'asc'
+                    }
+                }}
+            />
+        </ThemeProvider>
+    )
+}
+
+export default StopVehicleDetailsTable

--- a/frontend/src/components/tables/utils.js
+++ b/frontend/src/components/tables/utils.js
@@ -1,0 +1,30 @@
+import { createTheme } from "@mui/material";
+
+const getMuiTheme = () => createTheme({
+    components: {
+        MuiPaper: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: "#dcdbe8",
+                }
+            }
+        },
+        MuiTableCell: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: "#dcdbe8"
+                }
+            }
+        },
+        MuiTableRow: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: "#dcdbe8",
+                    borderColor: 'black'
+                }
+            }
+        },
+    }
+})
+
+export { getMuiTheme }

--- a/frontend/src/utils/stringFormatter.js
+++ b/frontend/src/utils/stringFormatter.js
@@ -1,0 +1,8 @@
+const titleCaseToSentence = (str) => {
+    return str
+      .replace(/_/g, ' ')
+      .toLowerCase()
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+  };
+
+export { titleCaseToSentence }


### PR DESCRIPTION
- in Alerts: changed casing of cause and effect columns (so it wouldn’t look like ‘MODIFIED_SERVICE’)
- in Alerts: split table into Warning and Info tables
- got rid of visibility toggling in tables
- show only 1 loading sign when expanding rows
- in line charts, round numbers to nearest decimal when hovering over points
- changed background colour of the tables inside the expandable rows